### PR TITLE
fix memory leak

### DIFF
--- a/Rdkafka.xs
+++ b/Rdkafka.xs
@@ -122,6 +122,7 @@ krd_assign(rdk, tplistsv = NULL)
             tpar = krd_parse_topic_partition_list(aTHX_ tplist);
         }
         RETVAL = rd_kafka_assign(rdk->rk, tpar);
+        rd_kafka_topic_partition_list_destroy(tpar);
     OUTPUT:
         RETVAL
 
@@ -160,6 +161,7 @@ krd_commit(rdk, tplistsv = NULL, async = 0)
             tpar = krd_parse_topic_partition_list(aTHX_ tplist);
         }
         RETVAL = rd_kafka_commit(rdk->rk, tpar, async);
+        rd_kafka_topic_partition_list_destroy(tpar);
     OUTPUT:
         RETVAL
 


### PR DESCRIPTION
Two rd_kafka_topic_partition_list_destroy calls were missing.