### PR TITLE
Add flush method, and explicit topic destroy

### DIFF
--- a/Rdkafka.xs
+++ b/Rdkafka.xs
@@ -282,6 +282,13 @@ krd_outq_len(rdk)
         RETVAL
 
 void
+krd_flush(rdk, timeout_ms)
+        rdkafka_t* rdk
+        int timeout_ms
+    CODE:
+        rd_kafka_flush(rdk->rk, timeout_ms);
+
+void
 krd_DESTROY(rdk)
         rdkafka_t* rdk
     CODE:
@@ -336,6 +343,12 @@ krdt_produce(rkt, partition, msgflags, payload, key)
 
 void
 krdt_DESTROY(rkt)
+        rd_kafka_topic_t* rkt
+    CODE:
+        rd_kafka_topic_destroy(rkt);
+
+void
+krdt_destroy(rkt)
         rd_kafka_topic_t* rkt
     CODE:
         rd_kafka_topic_destroy(rkt);

--- a/lib/Kafka/Librd.pm
+++ b/lib/Kafka/Librd.pm
@@ -176,6 +176,12 @@ messages
 
 return the current out queue length.
 
+=head2 flush
+
+    $kafka->flush($timeout_ms)
+
+wait until all outstanding produce requests, et.al, are completed.
+
 =head2 destroy
 
     $kafka->destroy
@@ -202,6 +208,12 @@ produce a message for the topic. I<$msgflags> can be RD_KAFKA_MSG_F_BLOCK in
 the future, but currently it should be set to 0, RD_KAFKA_MSG_F_COPY and
 RD_KAFKA_MSG_F_FREE must not be used, internally RD_KAFKA_MSG_F_COPY is always
 set.
+
+=head2 destroy
+
+    $topic->destroy
+
+destroy topic handle
 
 =head1 Kafka::Librd::Message
 


### PR DESCRIPTION
I noticed one of my test scripts sometimes doesn't shut down correctly.

From the librdkafka docs:

The proper termination sequence for Producers is:

     /* 1) Make sure all outstanding requests are transmitted and handled. */
     rd_kafka_flush(rk, 60*1000); /* One minute timeout */

     /* 2) Destroy the topic and handle objects */
     rd_kafka_topic_destroy(rkt);  /* Repeat for all topic objects held */
     rd_kafka_destroy(rk);

https://github.com/edenhill/librdkafka/blob/master/INTRODUCTION.md#termination

So I added the flush method and an explicit destroy for topic, and this seems to help


```
#!/usr/bin/env perl
use 5.014;
use strict;
use warnings;

use Kafka::Librd;
my $brokers = "localhost:9092";
my $topic = "test";

my $key = 1; # use partition key to messages are received in order

my $kafka = Kafka::Librd->new(Kafka::Librd::RD_KAFKA_PRODUCER, {});
print "VERSION: " . Kafka::Librd::rd_kafka_version();

my $added = $kafka->brokers_add($brokers);
say "Added $added brokers";

my $ktopic = $kafka->topic( $topic, {} );

send_message("start >>>>>");
sleep 1;

for (my $i=1; $i <= 10; $i++) {
   my $err = send_message("message: $i");
   $err and die "Couldn't produce: ", Kafka::Librd::Error::to_string($err);
   print "$i\n";
}

sleep 1;
send_message("end >>>");

#sleep 1 while $kafka->outq_len;

$kafka->flush(1000);
$kafka->destroy();

while (Kafka::Librd::rd_kafka_wait_destroyed(1000) == -1) {
  say "Some kafka resources are still allocated";
}
say "Shutdown complete";

sub send_message {
  my ($message) = @_;
  my $err = $ktopic->produce( -1, 0, $message, $key );
  $err and die "Couldn't produce: ", Kafka::Librd::Error::to_string($err);
}
```