### PR TITLE
travis-ci: update list of perl versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,8 @@ script:
 
 jobs:
   include:
-    - env: CIP_TAG=5.31
+    - env: CIP_TAG=5.33
+    - env: CIP_TAG=5.32
     - env: CIP_TAG=5.30
     - env: CIP_TAG=5.28
     - env: CIP_TAG=5.26


### PR DESCRIPTION
5.31 is not available anymore.
Add newest stable+blead version instead.