### PR TITLE
Implement last_error

### DIFF
--- a/Rdkafka.xs
+++ b/Rdkafka.xs
@@ -465,3 +465,12 @@ krde_to_name(code)
         RETVAL = rd_kafka_err2name(code);
     OUTPUT:
         RETVAL
+
+int
+krde_last_error()
+    CODE:
+        RETVAL = rd_kafka_last_error();
+    OUTPUT:
+        RETVAL
+
+

--- a/bin/kafka_producer.pl
+++ b/bin/kafka_producer.pl
@@ -98,8 +98,11 @@ while (<>) {
     chomp;
     last if $_ eq '.';
     my ( $msg, $key ) = split /\t/, $_, 2;
-    my $err = $ktopic->produce( -1, 0, $msg, $key );
-    $err and die "Couldn't produce: ", Kafka::Librd::Error::to_string($err);
+    my $status = $ktopic->produce( -1, 0, $msg, $key );
+    if ($status == -1){
+        my $err = Kafka::Librd::Error::last_error();
+        say "Couldn't produce: ", Kafka::Librd::Error::to_string($err);
+    }
 }
 
 sleep 1 while $kafka->outq_len;

--- a/bin/kafka_producer.pl
+++ b/bin/kafka_producer.pl
@@ -96,7 +96,7 @@ my $ktopic = $kafka->topic( $topic, {} );
 
 while (<>) {
     chomp;
-    break if $_ eq '.';
+    last if $_ eq '.';
     my ( $msg, $key ) = split /\t/, $_, 2;
     my $err = $ktopic->produce( -1, 0, $msg, $key );
     $err and die "Couldn't produce: ", Kafka::Librd::Error::to_string($err);

--- a/lib/Kafka/Librd.pm
+++ b/lib/Kafka/Librd.pm
@@ -171,7 +171,8 @@ return a L</Kafka::Librd::Topic>topic object, that can be used to produce
 messages
 
 If an error occurs during creation of the topic, C<undef> is returned. In such
-case use L</last_error> to obtain the corresponding error code!
+case use L</Kafka::Librd::Error::last_error> to obtain the corresponding error
+code!
 
 =head2 outq_len
 
@@ -213,7 +214,7 @@ RD_KAFKA_MSG_F_FREE must not be used, internally RD_KAFKA_MSG_F_COPY is always
 set.
 
 The returned status is -1 in case of an error, otherwise 0. The error code can
-be retrieved using the L<Kafka::Librd::Error::last_error|/last_error> function.
+be retrieved using the L</Kafka::Librd::Error::last_error> function.
 
 =head2 destroy
 
@@ -270,15 +271,15 @@ scalar reference. It will be filled with one of the following values:
 
 =head1 Kafka::Librd::Error
 
-=head2 to_string
+=head2 Kafka::Librd::Error::to_string
 
    my $error_message =  Kafka::Librd::Error::to_string($err)
 
 Convert an error code into a human-readable error description. Use this for
-error codes returned by L<Kafka::Librd::Error::last_error|/last_error> and
+error codes returned by L</Kafka::Librd::Error::last_error> and
 L<Kafka::Librd::Message::err|/err>.
 
-=head2 last_error
+=head2 Kafka::Librd::Error::last_error
 
     my $err = Kafka::Librd::Error::last_error
 

--- a/lib/Kafka/Librd.pm
+++ b/lib/Kafka/Librd.pm
@@ -170,6 +170,9 @@ close down the consumer
 return a L</Kafka::Librd::Topic>topic object, that can be used to produce
 messages
 
+If an error occurs during creation of the topic, C<undef> is returned. In such
+case use L</last_error> to obtain the corresponding error code!
+
 =head2 outq_len
 
     $len = $kafka->outq_len
@@ -202,12 +205,15 @@ provides the following method:
 
 =head2 produce
 
-    $err = $topic->produce($partition, $msgflags, $payload, $key)
+    $status = $topic->produce($partition, $msgflags, $payload, $key)
 
 produce a message for the topic. I<$msgflags> can be RD_KAFKA_MSG_F_BLOCK in
 the future, but currently it should be set to 0, RD_KAFKA_MSG_F_COPY and
 RD_KAFKA_MSG_F_FREE must not be used, internally RD_KAFKA_MSG_F_COPY is always
 set.
+
+The returned status is -1 in case of an error, otherwise 0. The error code can
+be retrieved using the L<Kafka::Librd::Error::last_error|/last_error> function.
 
 =head2 destroy
 
@@ -261,6 +267,30 @@ scalar reference. It will be filled with one of the following values:
 =item Kafka::Librd::RD_KAFKA_TIMESTAMP_LOG_APPEND_TIME
 
 =back
+
+=head1 Kafka::Librd::Error
+
+=head2 to_string
+
+=back
+
+=head1 Kafka::Librd::Error
+
+=head2 to_string
+
+   my $error_message =  Kafka::Librd::Error::to_string($err)
+
+Convert an error code into a human-readable error description. Use this for
+error codes returned by L<Kafka::Librd::Error::last_error|/last_error> and
+L<Kafka::Librd::Message::err|/err>.
+
+=head2 last_error
+
+    my $err = Kafka::Librd::Error::last_error
+
+Retrieve the last error state set by function calls L</topic> and L</produce>.
+This function should be called immediately after those functions, since they
+store error information globally.
 
 =cut
 

--- a/lib/Kafka/Librd.pm
+++ b/lib/Kafka/Librd.pm
@@ -272,12 +272,6 @@ scalar reference. It will be filled with one of the following values:
 
 =head2 to_string
 
-=back
-
-=head1 Kafka::Librd::Error
-
-=head2 to_string
-
    my $error_message =  Kafka::Librd::Error::to_string($err)
 
 Convert an error code into a human-readable error description. Use this for

--- a/t/produce.t
+++ b/t/produce.t
@@ -35,7 +35,7 @@ use Kafka::Librd qw();
     is $value, -1, "to large message produce returns error";
     is $err, Kafka::Librd::RD_KAFKA_RESP_ERR_MSG_SIZE_TOO_LARGE, "last error returns too large error";
 
-    # same size constrains apply to topic creation call
+    # same size constraints apply to topic creation call
     $topic = $kafka->topic($large_message, {});
     $err = Kafka::Librd::Error::last_error();
     is $topic, undef;

--- a/t/produce.t
+++ b/t/produce.t
@@ -1,0 +1,47 @@
+use strict;
+use warnings;
+use Test::More;
+use Scalar::Util qw(looks_like_number);
+use Kafka::Librd qw();
+
+{
+    my $max_message_size = 1000;
+
+    my $kafka = Kafka::Librd->new(
+        Kafka::Librd::RD_KAFKA_PRODUCER,
+        {
+            # this constrains the message size a well as topic name size
+            'message.max.bytes' => $max_message_size,
+        },
+    );
+    isa_ok $kafka, 'Kafka::Librd';
+
+    # test normal creation of a topic
+    my $topic = $kafka->topic("test", {});
+    my $err = Kafka::Librd::Error::last_error();
+    isa_ok $topic, 'Kafka::Librd::Topic';
+    is $err, Kafka::Librd::RD_KAFKA_RESP_ERR_NO_ERROR, "last error returns success";
+
+    # test a simple produce call
+    my $value = $topic->produce(1, 0, "test", 0);
+    $err = Kafka::Librd::Error::last_error();
+    is $value, 0, "simple message produce returns no error";
+    is $err, Kafka::Librd::RD_KAFKA_RESP_ERR_NO_ERROR, "last error returns success";
+
+    # provoke an error by trying to produce a message exceeding the maximum size
+    my $large_message = 'a' x ($max_message_size + 1);
+    $value = $topic->produce(1, 0, $large_message, 0);
+    $err = Kafka::Librd::Error::last_error();
+    is $value, -1, "to large message produce returns error";
+    is $err, Kafka::Librd::RD_KAFKA_RESP_ERR_MSG_SIZE_TOO_LARGE, "last error returns too large error";
+
+    # same size constrains apply to topic creation call
+    $topic = $kafka->topic($large_message, {});
+    $err = Kafka::Librd::Error::last_error();
+    is $topic, undef;
+    is $err, Kafka::Librd::RD_KAFKA_RESP_ERR__INVALID_ARG;
+}
+
+done_testing;
+
+__END__


### PR DESCRIPTION
This implements `rd_kafka_last_error` as `Kafka::Librd::Error::last_error`. The result can be used with `Kafka::Librd::Error::to_string`. There are unit tests and POD.

This should fix #33.