### PR TITLE
Add headers method to Kafka::Librd::Message

### DIFF
--- a/Rdkafka.xs
+++ b/Rdkafka.xs
@@ -433,6 +433,7 @@ krdm_headers(msg)
         size_t len, i;
         const char *name;
         const void *value;
+        void *ret;
     CODE:
         RETVAL = newHV();
         sv_2mortal((SV*)RETVAL);
@@ -443,7 +444,9 @@ krdm_headers(msg)
                 err = rd_kafka_header_get_all(hdrs, i, &name, &value, &len);
                 if (err == RD_KAFKA_RESP_ERR__NOENT)
                     break;
-                hv_store(RETVAL, name, strlen(name), newSVpvn(value, len), 0);
+                ret = hv_store(RETVAL, name, strlen(name), newSVpvn(value, len), 0);
+                if (ret == NULL)
+                    croak("hv_store failed");
             }
         }
         else if (err != RD_KAFKA_RESP_ERR__NOENT) {

--- a/Rdkafka.xs
+++ b/Rdkafka.xs
@@ -424,6 +424,34 @@ krdm_timestamp(msg,...)
     OUTPUT:
 	RETVAL
 
+HV*
+krdm_headers(msg)
+        rd_kafka_message_t *msg
+    PREINIT:
+        rd_kafka_resp_err_t err;
+        rd_kafka_headers_t *hdrs;
+        size_t len, i;
+        const char *name;
+        const void *value;
+    CODE:
+        RETVAL = newHV();
+        sv_2mortal((SV*)RETVAL);
+
+        err = rd_kafka_message_headers(msg, &hdrs);
+        if (err == RD_KAFKA_RESP_ERR_NO_ERROR) {
+            for (i = 0;; ++i) {
+                err = rd_kafka_header_get_all(hdrs, i, &name, &value, &len);
+                if (err == RD_KAFKA_RESP_ERR__NOENT)
+                    break;
+                hv_store(RETVAL, name, strlen(name), newSVpvn(value, len), 0);
+            }
+        }
+        else if (err != RD_KAFKA_RESP_ERR__NOENT) {
+            croak("Error parsing headers: %s", rd_kafka_err2str(err));
+        }
+    OUTPUT:
+        RETVAL
+
 void
 krdm_DESTROY(msg)
         rd_kafka_message_t* msg

--- a/lib/Kafka/Librd.pm
+++ b/lib/Kafka/Librd.pm
@@ -274,6 +274,10 @@ C<Kafka::Librd::RD_KAFKA_TIMESTAMP_LOG_APPEND_TIME>
 
 =back
 
+=head2 headers
+
+return message headers as a hash reference with name-value pairs
+
 =head1 Kafka::Librd::Error
 
 =head2 Kafka::Librd::Error::to_string


### PR DESCRIPTION
This PR adds a `Kafka::Librd::Message::headers` method, using the `rd_kafka_header_get_all` iterator from librdkafka and returning any headers in a hash reference. If there are no headers available, the method will return an empty hash reference.

The code has been tested manually against Kafka messages produced with and without headers using the https://github.com/dpkp/kafka-python library. Automated unit tests were impractical because of the ad-hoc XS required to instantiate a `rd_kafka_message_t*` to test against, which would complicate the implementation substantially.