### PR TITLE
Add support for producing headers

### DIFF
--- a/META.json
+++ b/META.json
@@ -28,7 +28,7 @@
       "configure" : {
          "requires" : {
             "Alien::Base::Wrapper" : "0",
-            "Alien::Librdkafka" : "v1.0.5",
+            "Alien::Librdkafka" : "v1.05",
             "ExtUtils::MakeMaker" : "6.64"
          }
       },

--- a/META.json
+++ b/META.json
@@ -28,7 +28,7 @@
       "configure" : {
          "requires" : {
             "Alien::Base::Wrapper" : "0",
-            "Alien::Librdkafka" : "v0.9.3",
+            "Alien::Librdkafka" : "v1.0.5",
             "ExtUtils::MakeMaker" : "6.64"
          }
       },

--- a/META.yml
+++ b/META.yml
@@ -7,7 +7,7 @@ build_requires:
   Test::More: '0.94'
 configure_requires:
   Alien::Base::Wrapper: '0'
-  Alien::Librdkafka: v0.9.3
+  Alien::Librdkafka: v1.0.5
   ExtUtils::MakeMaker: '6.64'
 dynamic_config: 1
 generated_by: 'ExtUtils::MakeMaker version 7.60, CPAN::Meta::Converter version 2.150010'

--- a/META.yml
+++ b/META.yml
@@ -7,7 +7,7 @@ build_requires:
   Test::More: '0.94'
 configure_requires:
   Alien::Base::Wrapper: '0'
-  Alien::Librdkafka: v1.0.5
+  Alien::Librdkafka: v1.05
   ExtUtils::MakeMaker: '6.64'
 dynamic_config: 1
 generated_by: 'ExtUtils::MakeMaker version 7.60, CPAN::Meta::Converter version 2.150010'

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use Config;
 use ExtUtils::MakeMaker 6.64;
-use Alien::Librdkafka 0.9.3;
+use Alien::Librdkafka 1.0.5;
 use Alien::Base::Wrapper qw( Alien::Librdkafka !export );
 use File::Spec ();
 
@@ -23,7 +23,7 @@ WriteMakefile(
     },
     CONFIGURE_REQUIRES => {
         'Alien::Base::Wrapper' => '0',
-        'Alien::Librdkafka'    => '0.9.3',
+        'Alien::Librdkafka'    => '1.0.5',
         'ExtUtils::MakeMaker'  => '6.64',
     },
     dist                => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use Config;
 use ExtUtils::MakeMaker 6.64;
-use Alien::Librdkafka 1.0.5;
+use Alien::Librdkafka 1.05;
 use Alien::Base::Wrapper qw( Alien::Librdkafka !export );
 use File::Spec ();
 
@@ -23,7 +23,7 @@ WriteMakefile(
     },
     CONFIGURE_REQUIRES => {
         'Alien::Base::Wrapper' => '0',
-        'Alien::Librdkafka'    => '1.0.5',
+        'Alien::Librdkafka'    => '1.05',
         'ExtUtils::MakeMaker'  => '6.64',
     },
     dist                => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },

--- a/Rdkafka.xs
+++ b/Rdkafka.xs
@@ -288,6 +288,74 @@ krd_flush(rdk, timeout_ms)
     CODE:
         rd_kafka_flush(rdk->rk, timeout_ms);
 
+int
+krd_producev(rdk, params)
+        rdkafka_t* rdk
+        HV* params
+    PREINIT:
+        rd_kafka_headers_t *hdrs;
+        SV **tsv, **psv, **msv, **ksv, **vsv, **hsv;
+        int msgflags, partition;
+        char *value, *topic, *key;
+        STRLEN vlen, klen;
+    CODE:
+        tsv = hv_fetchs(params, "topic", 0);
+        if (tsv == NULL || !SvOK(*tsv))
+            croak("topic must be defined");
+        topic = SvPVbyte_nolen(*tsv);
+
+        psv = hv_fetchs(params, "partition", 0);
+        if (psv == NULL)
+            partition = RD_KAFKA_PARTITION_UA;
+        else if (SvIOK(*psv))
+            partition = SvIV(*psv);
+        else
+            croak("partition must be a number");
+
+        msv = hv_fetchs(params, "msgflags", 0);
+        if (msv == NULL)
+            msgflags = 0;
+        else if (SvIOK(*msv))
+            msgflags = SvIV(*msv);
+        else
+            croak("msgflags must be a number");
+
+        ksv = hv_fetchs(params, "key", 0);
+        if (ksv != NULL && SvOK(*ksv)) {
+            key = SvPVbyte(*ksv, klen);
+        }
+        else {
+            key = NULL; klen = 0;
+        }
+
+        vsv = hv_fetchs(params, "value", 0);
+        if (vsv != NULL && SvOK(*vsv)) {
+            value = SvPVbyte(*vsv, vlen);
+        }
+        else {
+            value = NULL; vlen = 0;
+        }
+
+        hdrs = rd_kafka_headers_new(0);
+        hsv = hv_fetchs(params, "headers", 0);
+        if (hsv != NULL && SvOK(*hsv)) {
+            if (!SvROK(*hsv) || SvTYPE(SvRV(*hsv)) != SVt_PVHV)
+                croak("headers must be a hash reference");
+            krd_add_headers_from_hv(hdrs, (HV*)SvRV(*hsv));
+        }
+
+        RETVAL = rd_kafka_producev(rdk->rk,
+            RD_KAFKA_V_TOPIC(topic),
+            RD_KAFKA_V_PARTITION(partition),
+            RD_KAFKA_V_MSGFLAGS(msgflags | RD_KAFKA_MSG_F_COPY),
+            RD_KAFKA_V_KEY(key, klen),
+            RD_KAFKA_V_VALUE(value, vlen),
+            RD_KAFKA_V_HEADERS(hdrs),
+            RD_KAFKA_V_END
+        );
+    OUTPUT:
+        RETVAL
+
 void
 krd_DESTROY(rdk)
         rdkafka_t* rdk

--- a/Rdkafka.xs
+++ b/Rdkafka.xs
@@ -298,6 +298,7 @@ krd_producev(rdk, params)
         int msgflags, partition;
         char *value, *topic, *key;
         STRLEN vlen, klen;
+        I32 hlen;
     CODE:
         tsv = hv_fetchs(params, "topic", 0);
         if (tsv == NULL || !SvOK(*tsv))
@@ -336,12 +337,16 @@ krd_producev(rdk, params)
             value = NULL; vlen = 0;
         }
 
-        hdrs = rd_kafka_headers_new(0);
         hsv = hv_fetchs(params, "headers", 0);
         if (hsv != NULL && SvOK(*hsv)) {
             if (!SvROK(*hsv) || SvTYPE(SvRV(*hsv)) != SVt_PVHV)
                 croak("headers must be a hash reference");
+            hlen = hv_iterinit((HV*)SvRV(*hsv));
+            hdrs = rd_kafka_headers_new(hlen);
             krd_add_headers_from_hv(hdrs, (HV*)SvRV(*hsv));
+        }
+        else {
+            hdrs = rd_kafka_headers_new(0);
         }
 
         RETVAL = rd_kafka_producev(rdk->rk,
@@ -353,6 +358,9 @@ krd_producev(rdk, params)
             RD_KAFKA_V_HEADERS(hdrs),
             RD_KAFKA_V_END
         );
+
+        if (RETVAL != RD_KAFKA_RESP_ERR_NO_ERROR)
+            rd_kafka_headers_destroy(hdrs);
     OUTPUT:
         RETVAL
 

--- a/lib/Kafka/Librd.pm
+++ b/lib/Kafka/Librd.pm
@@ -173,6 +173,47 @@ If an error occurs during creation of the topic, C<undef> is returned. In such
 case use L</Kafka::Librd::Error::last_error> to obtain the corresponding error
 code!
 
+=head2 producev
+
+    $err = $kafka->producev(\%params)
+
+Produce a message and return an error code. On success, the error code is
+C<RD_KAFKA_RESP_ERR_NO_ERROR>. The error code can be converted to a string by
+L<Kafka::Librd::Error::to_string>.
+
+You probably only want this version if you need to send headers, otherwise use
+L<Kafka::Librd::Topic::produce> instead. The parameters you can pass are
+documented below.
+
+=head3 topic (required)
+
+The name of the topic.
+
+=head3 partition (optional)
+
+The partition number. Defaults to C<RD_KAFKA_PARTITION_UA>.
+
+=head3 msgflags (optional)
+
+The message flags.
+
+Please note that C<RD_KAFKA_MSG_F_COPY> is always set internally and
+C<RD_KAFKA_MSG_F_FREE> must I<not> be used.
+
+=head3 key (optional)
+
+The message key.
+
+=head3 value (optional)
+
+The message value. This is referred to as the payload in other places.
+
+=head3 headers (optional)
+
+The message headers as a hash reference with name-value pairs. Header names
+should be strings; header values can be any scalar. Don't use references
+because they will be automatically stringified.
+
 =head2 outq_len
 
     $len = $kafka->outq_len

--- a/rdkafkaxs.c
+++ b/rdkafkaxs.c
@@ -147,3 +147,23 @@ rd_kafka_topic_conf_t* krd_parse_topic_config(pTHX_ HV *params, char* errstr) {
 
     return topconf;
 }
+
+void
+krd_add_headers_from_hv(rd_kafka_headers_t *hdrs, HV *hv) {
+    SV *sv;
+    char *key;
+    I32 klen;
+    void *val;
+    STRLEN vlen;
+
+    hv_iterinit(hv);
+    while ((sv = hv_iternextsv(hv, &key, &klen)) != NULL) {
+        if (SvOK(sv)) {
+            val = SvPVbyte(sv, vlen);
+        }
+        else {
+            val = NULL; vlen = 0;
+        }
+        rd_kafka_header_add(hdrs, key, klen, val, vlen);
+    }
+}

--- a/rdkafkaxs.c
+++ b/rdkafkaxs.c
@@ -148,22 +148,24 @@ rd_kafka_topic_conf_t* krd_parse_topic_config(pTHX_ HV *params, char* errstr) {
     return topconf;
 }
 
+/*
+ * Add headers from a HV* to a preallocated rd_kafka_headers_t*.
+ *
+ * The caller is responsible for preparing the HV* for iteration by
+ * calling hv_iterinit on it before calling this function.
+ */
 void
 krd_add_headers_from_hv(rd_kafka_headers_t *hdrs, HV *hv) {
     SV *sv;
     char *key;
     I32 klen;
-    void *val;
-    STRLEN vlen;
 
-    hv_iterinit(hv);
     while ((sv = hv_iternextsv(hv, &key, &klen)) != NULL) {
-        if (SvOK(sv)) {
+        void *val = NULL;
+        STRLEN vlen = 0;
+
+        if (SvOK(sv))
             val = SvPVbyte(sv, vlen);
-        }
-        else {
-            val = NULL; vlen = 0;
-        }
         rd_kafka_header_add(hdrs, key, klen, val, vlen);
     }
 }

--- a/rdkafkaxs.h
+++ b/rdkafkaxs.h
@@ -12,3 +12,4 @@ rd_kafka_topic_partition_list_t* krd_parse_topic_partition_list(pTHX_ AV* tplist
 AV* krd_expand_topic_partition_list(pTHX_ rd_kafka_topic_partition_list_t* tpar);
 rd_kafka_conf_t* krd_parse_config(pTHX_ rdkafka_t* krd, HV* params);
 rd_kafka_topic_conf_t* krd_parse_topic_config(pTHX_ HV *params, char* errstr);
+void krd_add_headers_from_hv(rd_kafka_headers_t*, HV*);

--- a/t/producev.t
+++ b/t/producev.t
@@ -1,0 +1,81 @@
+use strict;
+use warnings;
+use Test::More;
+
+my $message_max_bytes = 1000;
+
+BEGIN { use_ok "Kafka::Librd" }
+my $krd = Kafka::Librd->new(
+    Kafka::Librd::RD_KAFKA_PRODUCER,
+    {
+        "message.max.bytes" => $message_max_bytes,
+    }
+);
+
+{
+    eval { $krd->producev };
+    like $@, qr[^Usage: Kafka::Librd::producev\(rdk, params\)],
+        "missing params";
+}
+
+{
+    eval { $krd->producev( {} ) };
+    like $@, qr[^topic must be defined], "missing topic";
+}
+
+{
+    eval { $krd->producev( { topic => undef, } ) };
+    like $@, qr[^topic must be defined], "undef topic";
+}
+
+{
+    eval {
+        $krd->producev({
+            topic     => "foo",
+            partition => "not a number",
+        });
+    };
+    like $@, qr[^partition must be a number], "wrong type for partition";
+}
+
+{
+    eval {
+        $krd->producev({
+            topic    => "foo",
+            msgflags => "not a number",
+        });
+    };
+    like $@, qr[^msgflags must be a number], "wrong type for msgflags";
+}
+
+{
+    eval {
+        $krd->producev({
+            topic   => "foo",
+            headers => "not a hash reference",
+        });
+    };
+    like $@, qr[^headers must be a hash reference], "wrong type for headers";
+}
+
+{
+    my $err = $krd->producev({
+        topic     => "foo",
+        value     => "a" x ($message_max_bytes + 1),
+    });
+    is $err, Kafka::Librd::RD_KAFKA_RESP_ERR_MSG_SIZE_TOO_LARGE,
+        "message size too large";
+}
+
+{
+    is $krd->producev({
+        topic     => "foo",
+        partition => 1,
+        msgflags  => 0,
+        key       => "key",
+        value     => "value",
+        headers   => { foo => 1, },
+    }), Kafka::Librd::RD_KAFKA_RESP_ERR_NO_ERROR , "happy path";
+}
+
+done_testing;


### PR DESCRIPTION
This PR adds a `Kafka::Librd::producev` method that optionally supports [message headers](https://cwiki.apache.org/confluence/display/KAFKA/KIP-82+-+Add+Record+Headers). This method wraps the variadic [`rd_kafka_producev`](https://github.com/confluentinc/librdkafka/blob/v1.3.0/src/rdkafka.h#L3721) that was extended to support headers in [`librdkafka 0.11.4`](https://github.com/confluentinc/librdkafka/releases/tag/v0.11.4). Accordingly, the version of the library was bumped from `librdkafka 0.9.3` to `librdkafka 1.3.0` by bumping to [Alien::Librdkafka 1.05](https://metacpan.org/release/PLICEASE/Alien-Librdkafka-1.05).

In terms of testing, the new functionality has been tested manually against a real Kafka server using the support for consuming headers added in #48. Unit tests have been added to check error handling, but, as mentioned in #18, testing against a real Kafka server is necessary for proper automated test coverage.